### PR TITLE
Close #3 exec custom callback after composer install

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,20 @@ This command exec the installation flow of composer's install. This process requ
 ```vim
 :ComposerInstall [--no-dev ..]
 ```
-This command exec `composer install`
+This command exec `composer install`. Now you can attach after this command a custom callback to exec your personal flow.
+```vim
+function! MyCallbackFunction()
+    exec ':silent ! ctags -a %'
+endfunction
+let g:composer_install_callback = "MyCallbackFunction"
+```
+In this example after every `composer install` I exec a ctags generation
 
 ```vim
 :ComposerJSON
 ```
 This command open `composer.json`
+
 
 ## Install
 ```vim

--- a/plugin/vim-composer.vim
+++ b/plugin/vim-composer.vim
@@ -21,8 +21,9 @@ if !exists("g:composer_cmd")
     endif
 endif
 
+
 command! -narg=* ComposerRun call s:ComposerRunFunc(<q-args>)
-command! -narg=* ComposerInstall call s:ComposerRunFunc("install ".<q-args>)
+command! -narg=* ComposerInstall call s:ComposerInstallFunc(<q-args>)
 command! ComposerGet call s:ComposerGetFunc()
 command! ComposerJSON call s:OpenComposerJSON()
 
@@ -40,5 +41,16 @@ function! s:OpenComposerJSON()
         exe "vsplit ./composer.json"
     else
         echo "Composer json doesn't exist"
+    endif
+endfunction
+
+if !exists("g:composer_install_callback")
+    let g:composer_install_callback = ""
+endif
+
+function! s:ComposerInstallFunc(arg)
+    exe s:ComposerRunFunc("install")
+    if len(g:composer_install_callback) > 0
+        exe "call ".g:composer_install_callback."()"
     endif
 endfunction


### PR DESCRIPTION
``` vim
:ComposerInstall [--no-dev ..]
```

This command exec `composer install`. Now you can attach after this command a custom callback to exec your personal flow.

``` vim
function! MyCallbackFunction()
    exec ':silent ! ctags -a %'
endfunction
let g:composer_install_callback = "MyCallbackFunction"
```

In this example after every `composer install` I exec a ctags generation
