### PR TITLE
Added a nice tip to use ComposerGet command "outside" vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ To run command for example `:ComposerRun validate` run command validate for your
 :ComposerGet
 ```
 This command exec the installation flow of composer's install. This process require `curl`
+Also remeber that it is possibile run this vim command without enter inside the
+editor: `$ vim -c 'ComposerGet' -c 'q'`
 
 ```vim
 :ComposerInstall [--no-dev ..]


### PR DESCRIPTION
Its amazing the way I can be faster with ComposerGet inside vim. But each time I run that command, I must go outside vim to run a command. So, .. this is a little tip, added in readme file, to tell users how can improve the user experience of vim through vim-composer
